### PR TITLE
Update dependencies to their latest semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "weather",
     "wikipedia",
     "youtube",
-	"csgo"
+    "csgo"
   ],
   "license": "GPL-3.0",
   "main": "bot.js",
@@ -33,26 +33,26 @@
     "test": "grunt --verbose"
   },
   "dependencies": {
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.20.0",
     "countdown": "^2.6.0",
     "get-youtube-id": "^1.0.0",
-    "irc": "^0.4.0",
+    "irc": "^0.4.1",
     "irc-colors": "^1.2.0",
-    "lodash": "^3.10.1",
-    "moment": "^2.10.6",
+    "lodash": "^4.2.1",
+    "moment": "^2.11.2",
     "moment-countdown": "^0.0.3",
     "moment-duration-format": "^1.3.0",
     "numeral": "^1.5.3",
-    "request": "^2.67.0",
+    "request": "^2.69.0",
     "youtube-api": "^1.4.0"
   },
   "devDependencies": {
     "eslint-stylish-config": "^0.0.2",
     "grunt": "^0.4.5",
-    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-contrib-jshint": "^0.12.0",
     "grunt-eslint": "^17.3.1",
-    "grunt-jscs": "^2.5.0",
-    "grunt-lintspaces": "^0.7.1",
+    "grunt-jscs": "^2.7.0",
+    "grunt-lintspaces": "^0.7.2",
     "jshint-summary": "^0.4.0",
     "load-grunt-tasks": "^3.4.0",
     "time-grunt": "^1.3.0"


### PR DESCRIPTION
Main reason for this was a security update that prevents DoS via moment.js
https://nodesecurity.io/advisories/moment_regular-expression-denial-of-service
